### PR TITLE
update Dockerfile and entrypoint.sh to be of more general use

### DIFF
--- a/.github/actions/pytest-in-sl7-container/Dockerfile
+++ b/.github/actions/pytest-in-sl7-container/Dockerfile
@@ -1,4 +1,5 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=hepcloud/decision-engine-ci
+FROM ${BASEIMAGE}
 COPY entrypoint.sh /entrypoint.sh
 
 # Identity information for the decisionengine user
@@ -20,11 +21,4 @@ RUN chown decisionengine:decisionengine /var/log/decisionengine /etc/decisioneng
 USER decisionengine
 WORKDIR /home/decisionengine
 
-# get code and modules we need
-RUN git clone https://github.com/HEPCloud/decisionengine.git /home/decisionengine/decisionengine/
-RUN python3 -m pip install --upgrade pip --user
-RUN python3 -m pip install --upgrade setuptools wheel setuptools-scm[toml] --user
-RUN cd decisionengine ; python3 setup.py develop --user
-
-USER decisionengine
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/pytest-in-sl7-container/entrypoint.sh
+++ b/.github/actions/pytest-in-sl7-container/entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -x
 ## cannot use -e as we lose the log that way
+CMD=${1:- -m pytest}
+LOGFILE=${2:- pytest.log}
 cd decisionengine
 python3 setup.py bdist_wheel
-# cannot use `tee` as it eats $? and we lose success/failure
-python3 -m pytest 2>&1 > pytest.log
-RC=$?
-cat pytest.log
-exit ${RC}
+python3 -m pip install -r requirements/requirements-runtime.txt
+python3 -m pip install -r requirements/requirements-develop.txt
+# make sure the pipe doesn't eat failures
+set -o pipefail
+# run the test
+python3 ${CMD} 2>&1 | tee ${LOGFILE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
   && yum -y clean all
 
 # set PATH for build and runtime
-ENV PATH="~/.local/bin:/usr/pgsql-${PG_VERSION}/bin:$PATH"
-ARG PATH="~/.local/bin:/usr/pgsql-${PG_VERSION}/bin:$PATH"
+ENV PATH="/usr/pgsql-${PG_VERSION}/bin:$PATH"
+ARG PATH="/usr/pgsql-${PG_VERSION}/bin:$PATH"
 # Install postgresql-${PG_VERSION}
 RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   && yum -y clean all
@@ -30,9 +30,12 @@ RUN yum -y install \
   rpm-build \
   && yum -y clean all
 
+# Install decisionengine requirements
 RUN git clone https://github.com/HEPCloud/decisionengine.git /tmp/decisionengine.git
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install --upgrade setuptools wheel setuptools-scm[toml]
-RUN cd /tmp/decisionengine.git ; python3 setup.py develop ; python3 -m pip install decisionengine[develop] ; python3 setup.py develop --uninstall
+
+RUN cd /tmp/decisionengine.git ; python3 setup.py bdist_wheel ; python3 -m pip install dist/*.whl ; \
+    python3 -m pip install decisionengine[develop] ; python3 -m pip uninstall -y decisionengine
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
With this update Dockerfiles and entrypoint.sh for SL7 pytest are of more general use.
When the pytest container is executed without arguments it is supposed to run pytest the same way it does now.
The container can be executes with extra arguments to run different tests

- to run flake8 tests:
 `docker run --rm -it --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} vitodb/decision-engine-ci:test_pytests  "-m pytest -m flake8 --flake8" "flake8.log"`

- to run pytests with coverage reports:
`docker run --rm -it --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} vitodb/decision-engine-ci:test_pytests "-m pytest --cov-report term --cov=decisionengine --no-cov-on-fail" "pytest.log"`

Though in the last case I got following warnings:
`Coverage.py warning: No data was collected. (no-data-collected)`
`WARNING: Failed to generate report: No data to report.`
`/home/decisionengine/.local/lib/python3.6/site-packages/pytest_cov/plugin.py:271: PytestWarning: Failed to generate report: No data to report.`
`  self.cov_controller.finish()`
